### PR TITLE
Github Workflows Cache and Checks

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -39,6 +39,7 @@ jobs:
           7z x qt563.7z
 
       - name: Save Qt to cache
+        if: steps.cache-qt.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           path: C:\Qt

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -3,8 +3,15 @@ name: Autobuild
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
+  call-prettier-workflow:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/prettier.yml
+
   build:
     name: Autobuild
 
@@ -14,14 +21,28 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Checkout submodules
-        run: git submodule update --init --recursive      
+        run: git submodule update --init --recursive
 
-      - name: Download Qt
+      - name: Get QT From Cache
+        id: cache-qt
+        uses: actions/cache/restore@v3
+        with:
+          path: C:\Qt
+          key: ${{ runner.os }}-Qt563 # don't think QT version will change?
+
+      - name: Download Qt if Needed
+        if: steps.cache-qt.outputs.cache-hit != 'true'
         run: |
           mkdir C:\Qt
           python resources\qt_download_helper.py
           cd C:\Qt
           7z x qt563.7z
+
+      - name: Save Qt to cache
+        uses: actions/cache/save@v3
+        with:
+          path: C:\Qt
+          key: ${{ runner.os }}-Qt563 # don't think QT version will change?
 
       - name: Build
         run: |
@@ -33,6 +54,7 @@ jobs:
           7z a ..\spelunky2-x64dbg-plugin-autobuild.zip C:\spelunky2-x64dbg-plugin-autobuild\
 
       - name: Create release
+        if: ${{ github.event_name != 'pull_request' }}
         uses: marvinpinto/action-automatic-releases@v1.1.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
@@ -42,4 +64,4 @@ jobs:
           prerelease: true
           title: "Autobuild"
           files: |
-            spelunky2-x64dbg-plugin-autobuild.zip          
+            spelunky2-x64dbg-plugin-autobuild.zip

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,43 @@
+name: Clang-Format Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      do_formatting:
+        description: "Run clang-format inplace formatting and commit the result"
+        required: true
+        default: "false"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.16.2
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.do_formatting != 'true' }}
+        with:
+          source: "src"
+          extensions: "inl,h,hpp,cpp"
+          exclude: "./src/game_api/lua_libs"
+          clangFormatVersion: 16
+
+      - uses: DoozyX/clang-format-lint-action@v0.16.2
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.do_formatting == 'true' }}
+        with:
+          source: "src"
+          extensions: "inl,h,hpp,cpp"
+          exclude: "./src/game_api/lua_libs"
+          clangFormatVersion: 16
+          inplace: true
+      - uses: EndBug/add-and-commit@v4
+        if: ${{ success() && github.event_name == 'workflow_dispatch' && github.event.inputs.do_formatting == 'true' }}
+        with:
+          author_name: Clang-Format Bot
+          author_email: fake.user@github.com
+          message: "Automated clang-format changes"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -20,17 +20,15 @@ jobs:
       - uses: DoozyX/clang-format-lint-action@v0.16.2
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.do_formatting != 'true' }}
         with:
-          source: "src"
+          source: "src include"
           extensions: "inl,h,hpp,cpp"
-          exclude: "./src/game_api/lua_libs"
           clangFormatVersion: 16
 
       - uses: DoozyX/clang-format-lint-action@v0.16.2
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.do_formatting == 'true' }}
         with:
-          source: "src"
+          source: "src include"
           extensions: "inl,h,hpp,cpp"
-          exclude: "./src/game_api/lua_libs"
           clangFormatVersion: 16
           inplace: true
       - uses: EndBug/add-and-commit@v4

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: creyD/prettier_action@v4.3
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event.inputs.do_formatting != 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.do_formatting != 'true' }}
         with:
           dry: True
           prettier_options: --check resources/Spelunky2.json

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,10 +1,8 @@
 name: Prettier
   
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
+
   workflow_dispatch:
     inputs:
       do_formatting:
@@ -18,13 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: creyD/prettier_action@v4.3
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.do_formatting != 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.inputs.do_formatting != 'true' }}
         with:
           dry: True
           prettier_options: --check resources/Spelunky2.json
 
       - uses: creyD/prettier_action@v4.3
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.do_formatting == 'true' }}
+        with:
+          prettier_options: --write resources/Spelunky2.json
+          commit_message: "Automated prettier changes"
+
+      - uses: creyD/prettier_action@v4.3
+        if: ${{ github.event_name == 'workflow_call' }}
         with:
           prettier_options: --write resources/Spelunky2.json
           commit_message: "Automated prettier changes"


### PR DESCRIPTION
Clang format does not do any changes automatically, just check, can be run manually from Actions with push automatic changes if needed. Prettier can also be run manually but that should not be necessary

I was lazy so i just made `autobuild.yml` do everything about Building and Pull Requests:

- It will call Prettier to format the Spelunky2.json file (skipped for PR's)
- Get QT from cache if exists and build
- And as normal create release (skipped for PR's)
